### PR TITLE
Fix Hammer AMI Integration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,8 +66,8 @@ dependencies {
 
 	// convenience stuff
 	// adds some useful annotations for data classes. does not add any dependencies
-	compileOnly("org.projectlombok:lombok:1.18.24")
-	annotationProcessor("org.projectlombok:lombok:1.18.24")
+	compileOnly("org.projectlombok:lombok:1.18.38")
+	annotationProcessor("org.projectlombok:lombok:1.18.38")
 
 	// adds some useful annotations for miscellaneous uses. does not add any dependencies, though people without the lib will be missing some useful context hints.
 	implementation("org.jetbrains:annotations:23.0.0")

--- a/src/main/java/io/github/yunivers/nihilo/compatibility/ami/HammerRecipeCategory.java
+++ b/src/main/java/io/github/yunivers/nihilo/compatibility/ami/HammerRecipeCategory.java
@@ -61,9 +61,9 @@ public class HammerRecipeCategory implements RecipeCategory
                 x += 18;
             }
 
-            itemStacks.set(0, new ItemStack(hammerWrapper.getInputs().get(0)));
+            itemStacks.set(0, hammerWrapper.getInputs().get(0));
             for (int i = 0; i < hammerWrapper.getOutputs().size(); i++)
-                itemStacks.set(i + 1, new ItemStack(hammerWrapper.getOutputs().get(i)));
+                itemStacks.set(i + 1, hammerWrapper.getOutputs().get(i));
         }
     }
 }

--- a/src/main/java/io/github/yunivers/nihilo/compatibility/ami/HammerRecipeCategory.java
+++ b/src/main/java/io/github/yunivers/nihilo/compatibility/ami/HammerRecipeCategory.java
@@ -34,7 +34,7 @@ public class HammerRecipeCategory implements RecipeCategory
 
     @Override
     public @NotNull AMIDrawable getBackground() {
-        return DrawableHelper.createDrawable("assets/nihilo/stationapi/textures/gui/ami/ami_hammer.png", 0, 0, 166, 58);
+        return DrawableHelper.createDrawable("assets/nihilo/stationapi/textures/gui/ami/ami_hammer.png", 2, 3, 160, 54);
     }
 
     @Override
@@ -52,12 +52,12 @@ public class HammerRecipeCategory implements RecipeCategory
         if (recipeWrapper instanceof HammerRecipeWrapper hammerWrapper)
         {
             GuiItemStackGroup itemStacks = recipeLayout.getItemStacks();
-            itemStacks.init(0, true, 73, 3);
+            itemStacks.init(0, true, 71, 0);
 
-            int x = 2;
+            int x = 0;
             for (int i = 0; i < hammerWrapper.getOutputs().size(); i++)
             {
-                itemStacks.init(i + 1, false, x, 36);
+                itemStacks.init(i + 1, false, x, 33);
                 x += 18;
             }
 

--- a/src/main/java/io/github/yunivers/nihilo/compatibility/ami/HammerRecipeHandler.java
+++ b/src/main/java/io/github/yunivers/nihilo/compatibility/ami/HammerRecipeHandler.java
@@ -24,6 +24,6 @@ public class HammerRecipeHandler implements RecipeHandler<Smashable>
 
     @Override
     public boolean isRecipeValid(@NotNull Smashable recipe) {
-        return recipe.hasOutput();
+        return recipe.isValid();
     }
 }

--- a/src/main/java/io/github/yunivers/nihilo/compatibility/ami/HammerRecipeHandler.java
+++ b/src/main/java/io/github/yunivers/nihilo/compatibility/ami/HammerRecipeHandler.java
@@ -24,6 +24,6 @@ public class HammerRecipeHandler implements RecipeHandler<Smashable>
 
     @Override
     public boolean isRecipeValid(@NotNull Smashable recipe) {
-        return recipe.hasItem();
+        return recipe.hasOutput();
     }
 }

--- a/src/main/java/io/github/yunivers/nihilo/compatibility/ami/HammerRecipeWrapper.java
+++ b/src/main/java/io/github/yunivers/nihilo/compatibility/ami/HammerRecipeWrapper.java
@@ -2,12 +2,20 @@ package io.github.yunivers.nihilo.compatibility.ami;
 
 import io.github.yunivers.nihilo.Nihilo;
 import io.github.yunivers.nihilo.items.tools.Hammer;
+import io.github.yunivers.nihilo.mixin.RecipesGuiAccessor;
 import io.github.yunivers.nihilo.registries.helpers.Smashable;
+import net.glasslauncher.mods.alwaysmoreitems.api.gui.AMIDrawable;
 import net.glasslauncher.mods.alwaysmoreitems.api.recipe.RecipeWrapper;
+import net.glasslauncher.mods.alwaysmoreitems.gui.DrawableHelper;
+import net.glasslauncher.mods.alwaysmoreitems.gui.screen.OverlayScreen;
+import net.glasslauncher.mods.alwaysmoreitems.recipe.Focus;
 import net.glasslauncher.mods.alwaysmoreitems.util.AlwaysMoreItems;
+import net.glasslauncher.mods.alwaysmoreitems.util.RecipeGuiLogic;
 import net.minecraft.block.Block;
 import net.minecraft.client.Minecraft;
+import net.minecraft.item.BlockItem;
 import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.lwjgl.util.Rectangle;
@@ -19,7 +27,8 @@ import java.util.List;
 public class HammerRecipeWrapper implements RecipeWrapper
 {
     private final Smashable smashable;
-    private static Rectangle clickArea = new Rectangle(74, 21, 16, 15);
+    private static final Rectangle clickArea = new Rectangle(74, 21, 16, 15);
+    private static final AMIDrawable focusHighlight = DrawableHelper.createDrawable("assets/nihilo/stationapi/textures/gui/ami/ami_hammer.png", 166, 0, 18, 18);
 
     public HammerRecipeWrapper(Smashable smashable)
     {
@@ -27,13 +36,13 @@ public class HammerRecipeWrapper implements RecipeWrapper
     }
 
     @Override
-    public List<Block> getInputs() {
-        return List.of(smashable.source);
+    public List<ItemStack> getInputs() {
+        return List.of(smashable.getSourceItemStack());
     }
 
     @Override
-    public List<Item> getOutputs() {
-        return List.of(smashable.getItem());
+    public List<ItemStack> getOutputs() {
+        return smashable.getResults();
     }
 
     @Override
@@ -42,7 +51,7 @@ public class HammerRecipeWrapper implements RecipeWrapper
     }
 
     @Override
-    public void drawAnimations(@NotNull Minecraft minecraft, int i, int i1) {
+    public void drawAnimations(@NotNull Minecraft minecraft, int recipeWidth, int recipeHeight) {
 
     }
 

--- a/src/main/java/io/github/yunivers/nihilo/compatibility/ami/HammerRecipeWrapper.java
+++ b/src/main/java/io/github/yunivers/nihilo/compatibility/ami/HammerRecipeWrapper.java
@@ -46,8 +46,31 @@ public class HammerRecipeWrapper implements RecipeWrapper
     }
 
     @Override
-    public void drawInfo(@NotNull Minecraft minecraft, int i, int i1, int i2, int i3) {
-
+    public void drawInfo(@NotNull Minecraft minecraft, int recipeWidth, int recipeHeight, int mouseX, int mouseY) {
+        ItemStack focus = ((RecipesGuiAccessor) OverlayScreen.INSTANCE.recipesGui).getLogic().getFocus().getStack();
+        if (focus == null) {
+            return;
+        }
+        int xOffset = 0;
+        int yOffset;
+        if (focus.getItem() instanceof BlockItem blockItem && smashable.source == blockItem.getBlock()) {
+            xOffset = 73;
+            yOffset = 3;
+        }
+        else {
+            List<ItemStack> results = smashable.getResults();
+            for (int i = 0; i < results.size(); i++) {
+                if (results.get(i).isItemEqual(focus)) {
+                    xOffset = 2 + (18 * i);
+                    break;
+                }
+            }
+            yOffset = 36;
+        }
+        if (xOffset == 0) {
+            return;
+        }
+        focusHighlight.draw(minecraft, xOffset, yOffset);
     }
 
     @Override

--- a/src/main/java/io/github/yunivers/nihilo/compatibility/ami/HammerRecipeWrapper.java
+++ b/src/main/java/io/github/yunivers/nihilo/compatibility/ami/HammerRecipeWrapper.java
@@ -47,6 +47,10 @@ public class HammerRecipeWrapper implements RecipeWrapper
 
     @Override
     public void drawInfo(@NotNull Minecraft minecraft, int recipeWidth, int recipeHeight, int mouseX, int mouseY) {
+        String conditions = smashable.getConditions();
+        if (conditions != null && !conditions.isEmpty()) {
+            minecraft.textRenderer.drawWithShadow(conditions, 83 - (minecraft.textRenderer.getWidth(conditions) / 2), 31 + 18 + 2, -1);
+        }
         ItemStack focus = ((RecipesGuiAccessor) OverlayScreen.INSTANCE.recipesGui).getLogic().getFocus().getStack();
         if (focus == null) {
             return;
@@ -61,11 +65,11 @@ public class HammerRecipeWrapper implements RecipeWrapper
             List<ItemStack> results = smashable.getResults();
             for (int i = 0; i < results.size(); i++) {
                 if (results.get(i).isItemEqual(focus)) {
-                    xOffset = 2 + (18 * i);
+                    xOffset = 18 * i;
                     break;
                 }
             }
-            yOffset = 36;
+            yOffset = 33;
         }
         if (xOffset == 0) {
             return;

--- a/src/main/java/io/github/yunivers/nihilo/items/tools/Hammer.java
+++ b/src/main/java/io/github/yunivers/nihilo/items/tools/Hammer.java
@@ -49,20 +49,22 @@ public class Hammer extends TemplateToolItem
     public boolean postMine(ItemStack stack, int blockId, int x, int y, int z, LivingEntity miner) {
         if (HammerRegistry.containsBlock(Block.BLOCKS[blockId]))
         {
-            ArrayList<Smashable> rewards = HammerRegistry.getRewards(Block.BLOCKS[blockId]);
+            ArrayList<Smashable> rewards = HammerRegistry.getRewards(Block.BLOCKS[blockId], miner, x, y, z);
             if (!rewards.isEmpty()) {
                 Nihilo.IgnoreNextItemEntity = blockId;
                 for (Smashable reward : rewards) {
                     if (!miner.world.isRemote && miner.world.random.nextFloat() <= reward.chance) {
-                        ItemEntity newItemEntity = new ItemEntity(miner.world, (double) x + 0.5D, (double) y + 0.5D, (double) z + 0.5D, new ItemStack(reward.getItem(), 1));
+                        for (ItemStack result : reward.getResults()) {
+                            ItemEntity newItemEntity = new ItemEntity(miner.world, (double) x + 0.5D, (double) y + 0.5D, (double) z + 0.5D, result.copy());
 
-                        double f3 = 0.05F;
-                        newItemEntity.velocityX = miner.world.random.nextGaussian() * f3;
-                        newItemEntity.velocityY = 0.2d;
-                        newItemEntity.velocityZ = miner.world.random.nextGaussian() * f3;
-                        newItemEntity.pickupDelay = 10;
+                            double f3 = 0.05F;
+                            newItemEntity.velocityX = miner.world.random.nextGaussian() * f3;
+                            newItemEntity.velocityY = 0.2d;
+                            newItemEntity.velocityZ = miner.world.random.nextGaussian() * f3;
+                            newItemEntity.pickupDelay = 10;
 
-                        miner.world.spawnEntity(newItemEntity);
+                            miner.world.spawnEntity(newItemEntity);
+                        }
                     }
                 }
             }
@@ -70,4 +72,6 @@ public class Hammer extends TemplateToolItem
 
         return super.postMine(stack, blockId, x, y, z, miner);
     }
+
+
 }

--- a/src/main/java/io/github/yunivers/nihilo/items/tools/Hammer.java
+++ b/src/main/java/io/github/yunivers/nihilo/items/tools/Hammer.java
@@ -60,6 +60,7 @@ public class Hammer extends TemplateToolItem
                         newItemEntity.velocityX = miner.world.random.nextGaussian() * f3;
                         newItemEntity.velocityY = 0.2d;
                         newItemEntity.velocityZ = miner.world.random.nextGaussian() * f3;
+                        newItemEntity.pickupDelay = 10;
 
                         miner.world.spawnEntity(newItemEntity);
                     }

--- a/src/main/java/io/github/yunivers/nihilo/mixin/RecipesGuiAccessor.java
+++ b/src/main/java/io/github/yunivers/nihilo/mixin/RecipesGuiAccessor.java
@@ -1,0 +1,13 @@
+package io.github.yunivers.nihilo.mixin;
+
+import net.glasslauncher.mods.alwaysmoreitems.gui.screen.RecipesGui;
+import net.glasslauncher.mods.alwaysmoreitems.util.RecipeGuiLogic;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(value = RecipesGui.class, remap = false)
+public interface RecipesGuiAccessor {
+
+    @Accessor
+    RecipeGuiLogic getLogic();
+}

--- a/src/main/java/io/github/yunivers/nihilo/registries/HammerRegistry.java
+++ b/src/main/java/io/github/yunivers/nihilo/registries/HammerRegistry.java
@@ -104,20 +104,6 @@ public class HammerRegistry extends SimpleRegistry<Smashable>
         // Sandstone
             .accept(nameOf(Block.SANDSTONE), new Smashable(Block.SANDSTONE, new ItemStack(Block.SAND), 1, 0))
 
-        // Info test
-            .accept(nameOf(Block.DIAMOND_BLOCK), new Smashable(Block.DIAMOND_BLOCK, new ItemStack(Block.COAL_ORE), 1, 0) {
-                @Override
-                public @Nullable String getConditions() {
-                    return "This sounds about right.";
-                }
-            })
-            .accept(nameOf(Block.DIAMOND_BLOCK), new Smashable(Block.DIAMOND_BLOCK, new ItemStack(Block.COAL_ORE), 1, 0) {
-                @Override
-                public @Nullable String getConditions() {
-                    return "This sounds about right.";
-                }
-            })
-
         // TODO: Netherrack Gravel
         ;
     }

--- a/src/main/java/io/github/yunivers/nihilo/registries/HammerRegistry.java
+++ b/src/main/java/io/github/yunivers/nihilo/registries/HammerRegistry.java
@@ -8,7 +8,8 @@ import io.github.yunivers.nihilo.registries.events.HammerRegistryEvent;
 import io.github.yunivers.nihilo.registries.helpers.Smashable;
 import net.mine_diver.unsafeevents.listener.EventListener;
 import net.minecraft.block.Block;
-import net.minecraft.item.Item;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.item.ItemStack;
 import net.modificationstation.stationapi.api.StationAPI;
 import net.modificationstation.stationapi.api.mod.entrypoint.Entrypoint;
 import net.modificationstation.stationapi.api.mod.entrypoint.EventBusPolicy;
@@ -41,12 +42,12 @@ public class HammerRegistry extends SimpleRegistry<Smashable>
         return false;
     }
 
-    public static ArrayList<Smashable> getRewards(Block block)
+    public static ArrayList<Smashable> getRewards(Block block, LivingEntity entity, int x, int y, int z)
     {
         ArrayList<Smashable> rewardList = new ArrayList<>();
 
         for (Smashable reward : INSTANCE)
-            if (reward.source == block && reward.hasOutput())
+            if (reward.source == block && reward.isValid() && reward.check(entity, x, y, z))
                 rewardList.add(reward);
 
         return rewardList;
@@ -83,23 +84,24 @@ public class HammerRegistry extends SimpleRegistry<Smashable>
     @EventListener
     public static void registerRewards(HammerRegistryEvent event)
     {
+        ItemStack stonePebble = new ItemStack(InitItems.STONE_PEBBLE);
         event.register(Namespace.MINECRAFT)
 
         // Stone
-            .accept(nameOf(Block.STONE), new Smashable(Block.STONE, InitItems.STONE_PEBBLE, 1.00f, 0.0f))
-            .accept(nameOf(Block.STONE), new Smashable(Block.STONE, InitItems.STONE_PEBBLE, 0.75f, 0.1f))
-            .accept(nameOf(Block.STONE), new Smashable(Block.STONE, InitItems.STONE_PEBBLE, 0.75f, 0.1f))
-            .accept(nameOf(Block.STONE), new Smashable(Block.STONE, InitItems.STONE_PEBBLE, 0.50f, 0.1f))
-            .accept(nameOf(Block.STONE), new Smashable(Block.STONE, InitItems.STONE_PEBBLE, 0.25f, 0.1f))
-            .accept(nameOf(Block.STONE), new Smashable(Block.STONE, InitItems.STONE_PEBBLE, 0.05f, 0.1f))
+            .accept(nameOf(Block.STONE), new Smashable(Block.STONE, stonePebble, 1.00f, 0.0f))
+            .accept(nameOf(Block.STONE), new Smashable(Block.STONE, stonePebble, 0.75f, 0.1f))
+            .accept(nameOf(Block.STONE), new Smashable(Block.STONE, stonePebble, 0.75f, 0.1f))
+            .accept(nameOf(Block.STONE), new Smashable(Block.STONE, stonePebble, 0.50f, 0.1f))
+            .accept(nameOf(Block.STONE), new Smashable(Block.STONE, stonePebble, 0.25f, 0.1f))
+            .accept(nameOf(Block.STONE), new Smashable(Block.STONE, stonePebble, 0.05f, 0.1f))
 
         // Break Down Cobblestone -> Gravel -> Sand -> Dust
-            .accept(nameOf(Block.COBBLESTONE), new Smashable(Block.COBBLESTONE, Block.GRAVEL, 1, 0))
-            .accept(nameOf(Block.GRAVEL), new Smashable(Block.GRAVEL, Block.SAND, 1, 0))
-            .accept(nameOf(Block.SAND), new Smashable(Block.SAND, InitBlocks.DUST, 1, 0))
+            .accept(nameOf(Block.COBBLESTONE), new Smashable(Block.COBBLESTONE, new ItemStack(Block.GRAVEL), 1, 0))
+            .accept(nameOf(Block.GRAVEL), new Smashable(Block.GRAVEL, new ItemStack(Block.SAND), 1, 0))
+            .accept(nameOf(Block.SAND), new Smashable(Block.SAND, new ItemStack(InitBlocks.DUST), 1, 0))
 
         // Sandstone
-            .accept(nameOf(Block.SANDSTONE), new Smashable(Block.SANDSTONE, Block.SAND, 1, 0))
+            .accept(nameOf(Block.SANDSTONE), new Smashable(Block.SANDSTONE, new ItemStack(Block.SAND), 1, 0))
 
         // TODO: Netherrack Gravel
         ;

--- a/src/main/java/io/github/yunivers/nihilo/registries/HammerRegistry.java
+++ b/src/main/java/io/github/yunivers/nihilo/registries/HammerRegistry.java
@@ -16,6 +16,7 @@ import net.modificationstation.stationapi.api.mod.entrypoint.EventBusPolicy;
 import net.modificationstation.stationapi.api.registry.*;
 import net.modificationstation.stationapi.api.util.Identifier;
 import net.modificationstation.stationapi.api.util.Namespace;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Objects;
@@ -102,6 +103,20 @@ public class HammerRegistry extends SimpleRegistry<Smashable>
 
         // Sandstone
             .accept(nameOf(Block.SANDSTONE), new Smashable(Block.SANDSTONE, new ItemStack(Block.SAND), 1, 0))
+
+        // Info test
+            .accept(nameOf(Block.DIAMOND_BLOCK), new Smashable(Block.DIAMOND_BLOCK, new ItemStack(Block.COAL_ORE), 1, 0) {
+                @Override
+                public @Nullable String getConditions() {
+                    return "This sounds about right.";
+                }
+            })
+            .accept(nameOf(Block.DIAMOND_BLOCK), new Smashable(Block.DIAMOND_BLOCK, new ItemStack(Block.COAL_ORE), 1, 0) {
+                @Override
+                public @Nullable String getConditions() {
+                    return "This sounds about right.";
+                }
+            })
 
         // TODO: Netherrack Gravel
         ;

--- a/src/main/java/io/github/yunivers/nihilo/registries/HammerRegistry.java
+++ b/src/main/java/io/github/yunivers/nihilo/registries/HammerRegistry.java
@@ -24,7 +24,7 @@ import java.util.Objects;
 public class HammerRegistry extends SimpleRegistry<Smashable>
 {
     public static final RegistryKey<Registry<Smashable>> KEY = RegistryKey.ofRegistry(Nihilo.NAMESPACE.id("smashable"));
-    public static final HammerRegistry INSTANCE = Registries.create(KEY, new HammerRegistry(), registry -> new Smashable(null, (Item)null, 0, 0), Lifecycle.experimental());
+    public static final HammerRegistry INSTANCE = Registries.create(KEY, new HammerRegistry(), registry -> null, Lifecycle.experimental());
 
     public HammerRegistry() {
         super(KEY, Lifecycle.experimental(), false);

--- a/src/main/java/io/github/yunivers/nihilo/registries/HammerRegistry.java
+++ b/src/main/java/io/github/yunivers/nihilo/registries/HammerRegistry.java
@@ -46,7 +46,7 @@ public class HammerRegistry extends SimpleRegistry<Smashable>
         ArrayList<Smashable> rewardList = new ArrayList<>();
 
         for (Smashable reward : INSTANCE)
-            if (reward.source == block && reward.hasItem())
+            if (reward.source == block && reward.hasOutput())
                 rewardList.add(reward);
 
         return rewardList;

--- a/src/main/java/io/github/yunivers/nihilo/registries/helpers/Smashable.java
+++ b/src/main/java/io/github/yunivers/nihilo/registries/helpers/Smashable.java
@@ -6,10 +6,10 @@ import net.minecraft.item.ItemStack;
 
 public class Smashable
 {
-    public Block source;
-    private ItemStack result;
-    public float chance;
-    public float luckMultiplier;
+    public final Block source;
+    private final ItemStack result;
+    public final float chance;
+    public final float luckMultiplier;
 
     public Smashable(Block source, ItemStack result, float chance, float luckMultiplier)
     {

--- a/src/main/java/io/github/yunivers/nihilo/registries/helpers/Smashable.java
+++ b/src/main/java/io/github/yunivers/nihilo/registries/helpers/Smashable.java
@@ -2,41 +2,30 @@ package io.github.yunivers.nihilo.registries.helpers;
 
 import net.minecraft.block.Block;
 import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
 
 public class Smashable
 {
     public Block source;
-    private Item item;
-    private Block block;
+    private ItemStack result;
     public float chance;
     public float luckMultiplier;
 
-    public Smashable(Block source, Item item, float chance, float luckMultiplier)
+    public Smashable(Block source, ItemStack result, float chance, float luckMultiplier)
     {
         this.source = source;
-        this.item = item;
+        this.result = result;
         this.chance = chance;
         this.luckMultiplier = luckMultiplier;
     }
 
-    public Smashable(Block source, Block block, float chance, float luckMultiplier)
+    public boolean hasOutput()
     {
-        this.source = source;
-        this.block = block;
-        this.chance = chance;
-        this.luckMultiplier = luckMultiplier;
-    }
-
-    public boolean hasItem()
-    {
-        return item != null || block != null;
+        return result != null;
     }
 
     public Item getItem()
     {
-        if (item != null)
-            return item;
-        else
-            return Item.BLOCK_ITEMS.get(block);
+        return result.getItem();
     }
 }

--- a/src/main/java/io/github/yunivers/nihilo/registries/helpers/Smashable.java
+++ b/src/main/java/io/github/yunivers/nihilo/registries/helpers/Smashable.java
@@ -1,31 +1,57 @@
 package io.github.yunivers.nihilo.registries.helpers;
 
+import lombok.Getter;
 import net.minecraft.block.Block;
-import net.minecraft.item.Item;
+import net.minecraft.entity.LivingEntity;
 import net.minecraft.item.ItemStack;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.List;
 
 public class Smashable
 {
     public final Block source;
-    private final ItemStack result;
+    @Getter
+    private final ItemStack sourceItemStack;
+    @Getter
+    public final List<ItemStack> results;
     public final float chance;
     public final float luckMultiplier;
 
     public Smashable(Block source, ItemStack result, float chance, float luckMultiplier)
     {
         this.source = source;
-        this.result = result;
+        sourceItemStack = new ItemStack(source);
+        this.results = List.of(result);
         this.chance = chance;
         this.luckMultiplier = luckMultiplier;
     }
 
-    public boolean hasOutput()
+    public Smashable(Block source, List<ItemStack> results, float chance, float luckMultiplier)
     {
-        return result != null;
+        this.source = source;
+        sourceItemStack = new ItemStack(source);
+        this.results = results;
+        this.chance = chance;
+        this.luckMultiplier = luckMultiplier;
     }
 
-    public Item getItem()
+    public boolean isValid()
     {
-        return result.getItem();
+        return results != null && !results.isEmpty();
+    }
+
+    /**
+     * Override to make this recipe conditional.
+     */
+    public boolean check(LivingEntity entity, int x, int y, int z) {
+        return true;
+    }
+
+    /**
+     * Override to show some extra text under the recipe explaining its conditions.
+     */
+    public @Nullable String getConditions() {
+        return null;
     }
 }

--- a/src/main/resources/nihilo.mixins.json
+++ b/src/main/resources/nihilo.mixins.json
@@ -10,6 +10,7 @@
   "server": [
   ],
   "client": [
+    "RecipesGuiAccessor"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Also:
- Updates lombok to fix a crash on newer jdks.
- Fixes hammered blocks being instantly pick-up-able.]
- Adds the ability to set a short description on smashable recipes.
- Makes smashable able to use multiple outputs. You may want to modify this so these can be chanced to reduce on the recipe spam.